### PR TITLE
2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@findaway/sandbox-cli",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": false,
   "description": "Tool to manage sandboxed web apps",
   "main": "index.js",


### PR DESCRIPTION
- Fix issue with S3 bucket name character limit. Bucket names will now truncate branch names to meet the character limit.
- Allow `srcDir` to be defined as `.` to deploy from the root of the project.